### PR TITLE
Disable the /docs and similar endpoint by default.

### DIFF
--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -6,6 +6,7 @@ import { ServiceList } from "./endpoints/serviceListFetch";
 import { StaffAvailabilityFetch } from "./endpoints/StaffAvailabilityFetch";
 import { CustomQuestionsFetch } from "./endpoints/customQuestionsFetch";
 import { AppointmentCreate } from "./endpoints/appointmentCreate";
+import { env } from "cloudflare:workers";
 
 // Start a Hono app
 const app = new Hono<{ Bindings: Env }>();
@@ -38,7 +39,9 @@ app.use('*', async (c, next) => {
 
 // Setup OpenAPI registry
 const openapi = fromHono(app, {
-  docs_url: "/docs",
+  docs_url: env.DOCS_URL || null,
+  redoc_url: env.REDOCS_URL || null,
+  openapi_url: env.OPENAPI_URL || null
 });
 
 // Register OpenAPI endpoints

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -3,6 +3,10 @@
 // Runtime types generated with workerd@1.20250604.0 2025-06-14 
 declare namespace Cloudflare {
 	interface Env {
+    OPENAPI_URL: string;
+    REDOCS_URL: string;
+    DOCS_URL: string;
+    ALLOWED_ORIGINS: string;
 		TENANT_ID: string;
 		CLIENT_ID: string;
 		CLIENT_SECRET: string;


### PR DESCRIPTION
This pull request introduces changes to the `src/worker/index.ts` file to enhance configurability by leveraging environment variables for OpenAPI documentation URLs. It also adds a new import for `env` from Cloudflare Workers to enable this functionality.